### PR TITLE
Integrated the classes to ShookREST

### DIFF
--- a/Models/Shook.cs
+++ b/Models/Shook.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace ShookModel.Models
 {
-    class Shook
+    public class Shook
     {
         #region Variables 
         private ObjectId Id { get; set; }

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,11 +1,13 @@
-﻿using System;
+﻿using MongoDB.Bson;
+using System;
 using System.Collections.Generic;
 
 namespace ShookModel.Models
 {
-    class User
+    public class User
     {
         #region Variables
+        public ObjectId Id { get; set; }
         public UserData UserData { get; set; }
         public List<Shook> Shooks { get; set; }
         public int CreatedShooks { get; private set; }
@@ -14,7 +16,10 @@ namespace ShookModel.Models
 
         public User()
         {
-
+            // TODO: Add method for calculating the CreatedShooks and WonShooks
+            // when a User instance is created.
+            CreatedShooks = 0;
+            WonShooks = 0;
         }
 
         #region Methods 

--- a/Models/UserData.cs
+++ b/Models/UserData.cs
@@ -3,14 +3,15 @@ using System;
 
 namespace ShookModel.Models
 {
-    class UserData
+    public class UserData
     {
         #region Variables 
-        private ObjectId Id { get; set; }
-        private string UserName { get; set; }
-        private Object ProfilePicture { get; set; }
+        public string UserName { get; set; }
+        // TODO: Find a proper data type for the profile picture
+        // which can be stored in the MongoDB.
+        public Object ProfilePicture { get; set; }
         // TODO: Add RegEx for email validation. 
-        private string EmailAddress { get => this.EmailAddress; set => this.EmailAddress = value; }
+        public string EmailAddress { get; set; }
         #endregion
     }
 }


### PR DESCRIPTION
The User, UserData and Shook classes are now available in the ShookREST and ShookApp project. Please use the ShookModel project for the data classes in the future. 
The User class had to have the ObjectId because the database required it (there would exist two ObjectIds if the ObjectId stayed in the UserData). 
All classes are now public because they were not usable.
Modified the getter and setter of UserData.EmailAddress because the tests with the MongoDB required it. 
Added a few TODOs